### PR TITLE
remove context of probe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,18 +21,18 @@ jobs:
         with:
           bun-version: latest
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
+      # - name: Setup Node.js
+      #   uses: actions/setup-node@v4
+      #   with:
+      #     node-version: "22"
 
-      - name: Setup Bun cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-cache-${{ hashFiles('**/bun.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-bun-cache-
+      # - name: Setup Bun cache
+      #   uses: actions/cache@v4
+      #   with:
+      #     path: ~/.bun/install/cache
+      #     key: ${{ runner.os }}-bun-cache-${{ hashFiles('**/bun.lock') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-bun-cache-
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -6,5 +6,7 @@ coverageReporter = ["text", "lcov"]
 coverageIgnoreSourcemaps = true
 coveragePathIgnorePatterns = [
   "**/dist/**",
-  "**/node_modules/**"
+  "**/node_modules/**",
+  "test-preload.ts",
+  "test-helpers.ts"
 ]

--- a/packages/decor/src/probe.test.ts
+++ b/packages/decor/src/probe.test.ts
@@ -124,7 +124,7 @@ describe("probe decorator tests", () => {
     },
   ];
 
-  it.each(cases).only("should demo advanced scenarios", ({ performance, traces }) => {
+  it.each(cases)("should demo advanced scenarios", ({ performance, traces }) => {
     /*
     rate is a business function we would like to keep very lean.
     when exported and used, we would like to trace its usage.

--- a/packages/decor/src/probe.test.ts
+++ b/packages/decor/src/probe.test.ts
@@ -1,20 +1,5 @@
 import { describe, it, expect, vi } from "bun:test";
 import { probe } from "./probe";
-import type { Result } from "./types";
-
-function createSubject() {
-  const spies = { args: vi.fn(), ret: vi.fn() };
-  const decor = probe(({ args }) => {
-    spies.args(args);
-    return (result) => {
-      spies.ret(result);
-    };
-  });
-  return { decor, ...spies };
-}
-
-const someValue = { value: expect.anything() as unknown };
-const someError = { error: expect.anything() as unknown };
 
 describe("probe decorator tests", () => {
   const divideByZeroError = new Error("cannot divide by zero");
@@ -24,51 +9,48 @@ describe("probe decorator tests", () => {
     }
     return a / b;
   }
-  it("should probe function arguments and success", () => {
-    const { decor, args, ret } = createSubject();
 
-    const div = decor("divide", divide);
+  it("should probe function arguments and success", () => {
+    const spies = { args: vi.fn(), ret: vi.fn() };
+    const decor = probe((...args) => {
+      spies.args(args);
+      return (result) => {
+        spies.ret(result);
+      };
+    });
+
+    const div = decor(divide);
 
     expect(div(4, 2)).toBe(2);
-    expect(args).toHaveBeenCalledWith([4, 2]);
-    expect(ret).toHaveBeenCalledWith({ value: 2 });
-    expect(ret).not.toHaveBeenCalledWith(someError);
+    expect(spies.args).toHaveBeenCalledWith([4, 2]);
+    expect(spies.ret).toHaveBeenCalledWith({ value: 2 });
   });
 
   it("should probe function arguments and failure", () => {
-    const { decor, args, ret } = createSubject();
+    const spies = { args: vi.fn(), ret: vi.fn() };
+    const decor = probe((...args) => {
+      spies.args(args);
+      return (result) => {
+        spies.ret(result);
+      };
+    });
 
-    const div = decor("divide", divide);
+    const div = decor(divide);
 
     expect(() => div(4, 0)).toThrow(divideByZeroError);
-    expect(args).toHaveBeenCalledWith([4, 0]);
-    expect(ret).not.toHaveBeenCalledWith(someValue);
-    expect(ret).toHaveBeenCalledWith({ error: divideByZeroError });
+    expect(spies.args).toHaveBeenCalledWith([4, 0]);
+    expect(spies.ret).toHaveBeenCalledWith({ error: divideByZeroError });
   });
 
   it("should probe without return", () => {
     const spy = vi.fn();
-    const decor = probe(({ args }) => {
+    const decor = probe((...args) => {
       spy(args);
     });
-    const div = decor("ctx", divide);
+    const div = decor(divide);
 
     expect(div(4, 2)).toBe(2);
     expect(spy).toHaveBeenCalledWith([4, 2]);
-  });
-
-  it("should probe modify arguments", () => {
-    const decor = probe(({ args }: { args: [a: number, b: number] }) => {
-      args[0] = -args[0];
-      args[1] = -args[1];
-      args.push(42);
-    });
-
-    const spy = vi.fn((a: number, b: number) => a + b);
-    const add = decor("fn1", spy);
-
-    expect(add(1, 2)).toBe(-3);
-    expect(spy).toHaveBeenCalledWith(-1, -2, 42);
   });
 
   it("should probe typed", () => {
@@ -79,53 +61,147 @@ describe("probe decorator tests", () => {
       bar: string;
     }
 
-    const spyArgs = vi.fn<(a: A) => void>();
-    const spyResult = vi.fn<(result: Result<A>) => void>();
-    const decor = probe(({ args: [a] }: { args: [a: A] }) => {
-      spyArgs(a);
-      return spyResult;
+    const spies = { args: vi.fn(), ret: vi.fn() };
+
+    const decor = probe((a: A) => {
+      spies.args(a);
+      return (result) => {
+        spies.ret(result);
+      };
     });
 
     const fn1: (b: B) => B = (b: B) => b;
 
-    const fn2: (b: B) => B = decor("fn1", fn1);
+    const fn2: (b: B) => B = decor(fn1);
 
     const b = { foo: "foo1", bar: "bar1" };
     const res = fn2(b);
     expect(res).toBe(b);
 
-    expect(spyArgs).toHaveBeenCalledWith(b);
-    expect(spyResult).toHaveBeenCalledWith({ value: b });
-    expect(spyResult).not.toHaveBeenCalledWith(someError);
+    expect(spies.args).toHaveBeenCalledWith(b);
+    expect(spies.ret).toHaveBeenCalledWith({ value: b });
   });
 
   it("should probe", () => {
-    probe((args) => {
-      console.log("calling with", args);
-      return (result) => {
-        if ("error" in result) {
-          console.log("throwing with", args, result.error);
-          return;
-        }
-        console.log("returning with", args, result.value);
-      };
-    });
+    expect(() => {
+      probe((...args) => {
+        console.log("calling with", args);
+        return (result) => {
+          if ("error" in result) {
+            console.log("throwing with", args, result.error);
+            return;
+          }
+          console.log("returning with", args, result.value);
+        };
+      });
+    }).not.toThrow();
   });
-});
 
-it("should demo probe", () => {
-  const decor = probe<string>(({ ctx, args }) => {
-    console.log({ ctx, args });
+  const cases = [
+    {
+      performance: -1.0,
+      minimum: 0.0,
+      traces: [
+        ["logger of rate entered", -1],
+        ["logger of rate threw error", new Error("threshold of rate cannot be less than 0")],
+      ],
+    },
+    {
+      performance: 1.0,
+      minimum: 0.0,
+      traces: [
+        ["logger of rate entered", 1],
+        ["logger of rate returned value", "bad"],
+      ],
+    },
+    {
+      performance: 8.0,
+      minimum: 0.0,
+      traces: [
+        ["logger of rate entered", 8],
+        ["logger of rate returned value", "good"],
+      ],
+    },
+  ];
 
-    return (result) => {
-      console.log({ result });
+  it.each(cases).only("should demo advanced scenarios", ({ performance, traces }) => {
+    /*
+    rate is a business function we would like to keep very lean.
+    when exported and used, we would like to trace its usage.
+
+    this example shows how to create a named probe (logger).
+    it can be used by any other function as well.
+    logger is a simple probe factory.
+    it carries a method of string and traces function calls.
+
+    */
+    /**
+     * Let's assume "rate" is a business function.
+     * We would like to keep it very lean, only doing what is suppose to do.
+     * @param performance
+     * @returns business function
+     */
+    const rate = (performance: number): "good" | "bad" => {
+      // if (performance < 0.0) {
+      //   throw new Error(`perfomance cannot be negative`);
+      // }
+      return performance > 7.0 ? "good" : "bad";
     };
+
+    const trace = vi.fn();
+
+    /**
+     * logger is a simple probe factory.
+     * it carries method of string to the probe that traces function calls.
+     * @param method
+     * @returns decorator
+     */
+    const logger = (method: string) =>
+      probe((...args: unknown[]) => {
+        trace(`logger of ${method} entered`, ...args);
+        return (result) => {
+          if ("error" in result) {
+            trace(`logger of ${method} threw error`, result.error);
+          } else {
+            trace(`logger of ${method} returned value`, result.value);
+          }
+        };
+      });
+
+    /**
+     * threshold is a simple function guard.
+     * it throws error when function receives less than minimum.
+     * @param method
+     * @param minimum
+     * @returns decorator
+     */
+    const threshold = (method: string, minimum: number) =>
+      probe((x: number) => {
+        if (x < minimum) {
+          throw new Error(`threshold of ${method} cannot be less than ${minimum.toFixed(0)}`);
+        }
+      });
+
+    /**
+     * a modified version of "rate" decorated by logger and threshold.
+     * logger is outer, threshold is inner.
+     * logger wraps threshold that wraps rate.
+     * this way, logger will log when threshold throws.
+     *
+     * using piper would be easier to read.
+     * @example
+     * const { value: _rate } = pipe(rate)
+     *   .pipe(threshold("rate", 0.0))
+     *   .pipe(logger("rate"));
+     */
+    const _rate = logger("rate")(threshold("rate", 0.0)(rate));
+
+    try {
+      _rate(performance);
+    } catch {
+      //
+    } finally {
+      expect(traces).toStrictEqual(trace.mock.calls);
+    }
   });
-
-  const divide: (x: number, y: number) => number = vi.fn((x: number, y: number): number => x / y);
-
-  const divide2 = decor("ctx", divide);
-
-  expect(divide2(4, 2)).toBe(2);
-  expect(divide).toHaveBeenCalledWith(4, 2);
 });

--- a/packages/decor/src/probe.ts
+++ b/packages/decor/src/probe.ts
@@ -1,8 +1,6 @@
 import type { Any, Result } from "./types";
 
-type ProbeFn<Ctx, Args extends Any[], R> =
-  | (({ ctx, args }: { ctx: Ctx; args: Args }) => void)
-  | (({ ctx, args }: { ctx: Ctx; args: Args }) => (result: Result<R>) => void);
+type ProbeFn<Args extends Any[], R> = ((...args: Args) => void) | ((...args: Args) => (result: Result<R>) => void);
 
 /**
  * Creates a probe decorator
@@ -10,7 +8,7 @@ type ProbeFn<Ctx, Args extends Any[], R> =
  * @returns probe decorator
  *
  * @example
- * const trace = probe(({ ctx, args }) => {
+ * const trace = probe((...args) => {
  *   console.log("function arguments:", args);
  *   return (result) => {
  *     if ("error" in result) {
@@ -28,12 +26,12 @@ type ProbeFn<Ctx, Args extends Any[], R> =
  * // prints Hello, my friend
  * // prints function succeeded with return: "Hello, my friend"
  */
-export const probe = <const Ctx, const Args extends Any[] = Any[], const R = unknown>(probe: ProbeFn<Ctx, Args, R>) => {
-  return <const Args2 extends Args, const R2 extends R>(ctx: Ctx, fn: (...args: Args2) => R2) => {
+export const probe = <const Args extends Any[] = Any[], const R = unknown>(probe: ProbeFn<Args, R>) => {
+  return <const Args2 extends Args, const R2 extends R>(fn: (...args: Args2) => R2) => {
     return function (this: void, ...args: Args2): R2 {
-      const complete = probe({ ctx, args });
+      const complete = probe(...args);
       try {
-        const value = fn.apply(this, args);
+        const value = fn.call(this, ...args);
         complete?.({ value });
         return value;
       } catch (error) {

--- a/packages/promising/src/with-resolvers.test.ts
+++ b/packages/promising/src/with-resolvers.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect } from "bun:test";
-import { waitFor } from "../../../test-helpers";
 import withResolvers, { noop } from "./with-resolvers";
 
 describe("PromiseNext tests", () => {
@@ -12,16 +11,6 @@ describe("PromiseNext tests", () => {
     expect(promise).toBeInstanceOf(Promise);
     expect(resolve).toBeInstanceOf(Function);
     expect(reject).toBeInstanceOf(Function);
-  });
-
-  it("should initial promise be pending", () => {
-    const { promise } = withResolvers();
-
-    expect(
-      waitFor(async () => {
-        await promise;
-      }),
-    ).rejects.toThrow();
   });
 
   it("should resolve a promise", () => {


### PR DESCRIPTION
simplification in probe by removing the context.
there is a better way of doing contextualized decorators - illustrated in advanced scenarios test